### PR TITLE
Removes the entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,3 @@ RUN gcloud config set core/disable_usage_reporting true && \
     gcloud config set metrics/environment github_docker_image
 
 VOLUME ["/home/deploy/.config", "/home/deploy/.kube"]
-ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
There is a cmd set in the foundations image that we can leverage for
desktop behavior. but the more important reasoning behind this change
stems in the jenkins plugin behavior.

https://issues.jenkins-ci.org/browse/JENKINS-33149

hat/tip to mr ceppi on finding this one.